### PR TITLE
Extract underlying functionality into a library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "textmachine"
+description = "Opinionated, Simple, Hyper-minimal Pandoc-based SSG"
 version = "0.1.0"
 edition = "2024"
+license = "MIT"
+repository = "https://github.com/EcSolticia/textmachine"
 
 [dependencies]
 clap = { version = "4.5.41", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod machine;
+
+pub use machine::CmdArgs;
+pub use machine::execute;
+pub use machine::execute_cmd;

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -9,9 +9,9 @@ mod output;
 #[command(version, about, long_about = None)]
 pub struct CmdArgs {
     #[arg(short, long)]    
-    input_path: PathBuf,
+    pub input_path: PathBuf,
     #[arg(short, long)]
-    output_path: PathBuf
+    pub output_path: PathBuf
 }
 impl CmdArgs {
     fn mirror_input_path(&self, path: PathBuf) -> PathBuf {

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -32,9 +32,7 @@ impl CmdArgs {
     }
 }
 
-pub fn execute_cmd() {
-    let args: CmdArgs = CmdArgs::parse();
-
+pub fn execute(args: CmdArgs) {
     match input::TracedPages::trace_pages(&args.input_path) {
         Ok(traced_pages) => {
             let output_pages: output::OutputPages = output::OutputPages::new(traced_pages, &args);
@@ -46,7 +44,12 @@ pub fn execute_cmd() {
             println!("{:#?}", e);
         }
     }
+}
 
+pub fn execute_cmd() {
+    let args: CmdArgs = CmdArgs::parse();
+
+    execute(args);
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-mod machine;
+use textmachine;
 
 fn main() {
-    machine::execute_cmd();
+    textmachine::execute_cmd();
 }


### PR DESCRIPTION
Currently, `textmachine` as a Cargo package only contains a binary. This binary executes the functionalities of `textmachine` based on command line arguments. However, the workings of the tool is fully encapsulated by the `machine` module in the package. This makes it easy to decouple the `machine` module from the executable and make it into a library.

This PR will extract the underlying functionality of `textmachine` into a library. This will enhance the composability of the tool.

By defining `machine::execute`, it also decouples the core execution of `textmachine` from command-line argument parsing. This new function is now used by the existing `execute_cmd` following argument parsing. The function `execute` can also be used directly from any other Rust program that uses `textmachine` with a `machine::CmdArgs` struct as input.